### PR TITLE
Fix the Joystick in the EF24

### DIFF
--- a/TriquetraInput2/Binding.cs
+++ b/TriquetraInput2/Binding.cs
@@ -273,22 +273,33 @@ namespace Triquetra.Input
                     if (interactable == null)
                         return;
                     
-                    switch (VRInteractType)
+                    if (IsOffsetAxis)
+                        Interactions.Interact(interactable, GetAxisAsFloat(joystickValue));
+                    else
                     {
-                        case VRInteractType.FixedValue:
-                            if (GetButtonPressed(joystickValue))
-                                Interactions.Interact(interactable, Value);
-                            else
-                                Interactions.AntiInteract(interactable);
-                            break;
-                        case VRInteractType.Default:
-                            if (GetButtonPressed(joystickValue))
-                                Interactions.Interact(interactable);
-                            else
-                                Interactions.AntiInteract(interactable);
-                            break;
-                        default:
-                            throw new ArgumentOutOfRangeException();
+                        switch (VRInteractType)
+                        {
+                            case VRInteractType.FixedValue:
+                                if (GetButtonPressed(joystickValue))
+                                    Interactions.Interact(interactable, Value);
+                                else
+                                    Interactions.AntiInteract(interactable);
+                                break;
+                            case VRInteractType.Default:
+                                if (GetButtonPressed(joystickValue))
+                                    Interactions.Interact(interactable, antiClockwise: false);
+                                else
+                                    Interactions.AntiInteract(interactable);
+                                break;
+                            case VRInteractType.Anticlockwise:
+                                if (GetButtonPressed(joystickValue))
+                                    Interactions.Interact(interactable, antiClockwise: true);
+                                else
+                                    Interactions.AntiInteract(interactable);
+                                break;
+                            default:
+                                throw new ArgumentOutOfRangeException();
+                        }
                     }
                 }
                 else if (OutputAction == ControllerAction.MFDInteract || OutputAction == ControllerAction.MMFDInteract)

--- a/TriquetraInput2/Binding.cs
+++ b/TriquetraInput2/Binding.cs
@@ -96,8 +96,8 @@ namespace Triquetra.Input
 
         public Binding()
         {
-            NextJoystick();
         }
+        
         public Binding(bool isKeyboard)
         {
             if (isKeyboard)

--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -605,7 +605,16 @@ namespace Triquetra.Input
 
             internal static VRJoystick FindJoystick()
             {
-                return GameObject.FindObjectOfType<VRJoystick>(false);
+                var joysticks = GameObject.FindObjectsOfType<VRJoystick>(false);
+
+                var joystick = joysticks.FirstOrDefault();
+                if (joysticks.Length > 1)
+                {
+                    //EF24 has 3 joysticks (front and the two backseat ones)
+                    joystick = joysticks.FirstOrDefault(stick => stick.name == "joyInteractable_sideFront");
+                }
+
+                return joystick;
             }
 
             private static bool menuButtonPressed = false;

--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -55,7 +55,8 @@ namespace Triquetra.Input
     public enum VRInteractType
     {
         Default,
-        FixedValue
+        FixedValue,
+        Anticlockwise
     }
 
     public enum MFDAction

--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -678,16 +678,10 @@ namespace Triquetra.Input
                     courseLeftPressed = buttonPressed;
             }
 
-            private static float headingRate;
+
             private static float timeHeadingHeld;
-            
-            private static float altitudeRate;
             private static float timeAltitudeHeld;
-            
-            private static float speedRate;
             private static float timeSpeedHeld;
-            
-            private static float courseRate;
             private static float timeCourseHeld;
 
             public static void UpdateAutopilot()

--- a/TriquetraInput2/Interactions.cs
+++ b/TriquetraInput2/Interactions.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using UnityEngine;
+
+namespace Triquetra.Input
+{
+    public static class Interactions
+    {
+        const float knobTwistSpeed = 0.025f;
+        public static void TwistKnob(VRTwistKnob twistKnob, bool antiClockwise, float delta = knobTwistSpeed)
+        {
+            //twistKnob.OnTwistDelta?.Invoke(antiClockwise ? -0.1f : 0.1f);
+            twistKnob.SetKnobValue(twistKnob.currentValue + (antiClockwise ? -knobTwistSpeed : knobTwistSpeed));
+        }
+
+        public static void MoveLever(VRLever lever, int delta = 1, bool clamp = false)
+        {
+            int nextState;
+            if (clamp)
+                nextState = Math.Max(Math.Min(lever.currentState + delta, lever.states - 1), 0);
+            else
+                nextState = (lever.currentState + delta) % lever.states;
+            lever.RemoteSetState(nextState);
+        }
+        
+        public static void SetLever(VRLever lever, int state)
+        {
+            state = Mathf.Clamp(state, 0, lever.states - 1);
+            lever.RemoteSetState(state);
+        }
+
+        public static void MoveTwistKnobInt(VRTwistKnobInt twistKnobInt, int delta = 1, bool clamp = false)
+        {
+            int nextState;
+            if (clamp)
+                nextState = Math.Max(Math.Min(twistKnobInt.currentState + delta, twistKnobInt.states - 1), 0);
+            else
+                nextState = (twistKnobInt.currentState + delta) % twistKnobInt.states;
+            twistKnobInt.RemoteSetState(nextState);
+        }
+
+        public static void SetTwistKnobInt(VRTwistKnobInt twistKnobInt, int state)
+        {
+            state = Mathf.Clamp(state, 0, twistKnobInt.states - 1);
+            twistKnobInt.RemoteSetState(state);
+        }
+
+        public static void MoveThrottle(VRThrottle throttle, float delta)
+        {
+            throttle.RemoteSetThrottleForceEvents(Math.Min(Math.Max(throttle.currentThrottle + delta, 0f), 1f));
+        }
+        public static void SetThrottle(VRThrottle throttle, float value)
+        {
+            throttle.RemoteSetThrottleForceEvents(Math.Min(Math.Max(value, 0f), 1f));
+        }
+
+        public static void Interact(VRInteractable interactable, int value = -1)
+        {
+            VRLever lever = interactable.GetComponent<VRLever>();
+            VRTwistKnobInt twistKnobInt = interactable.GetComponent<VRTwistKnobInt>();
+            VRButton button = interactable.GetComponent<VRButton>();
+            EjectHandle eject = interactable.GetComponent<EjectHandle>();
+            VRDoor door = interactable.GetComponent<VRDoor>();
+            VRKeyboard.VRKey vrKey = interactable.GetComponent<VRKeyboard.VRKey>();
+
+            if (lever != null)
+            {
+                if (value != -1)
+                    SetLever(lever, value);
+                else
+                    MoveLever(lever, 1);
+            }
+            else if (twistKnobInt != null)
+            {
+                if (value != -1)
+                    SetTwistKnobInt(twistKnobInt, value);
+                else
+                    MoveTwistKnobInt(twistKnobInt, 1);
+            }
+            else if (vrKey != null)
+            {
+                vrKey.OnPress();
+            }
+            else if (button != null)
+            {
+                interactable.StartInteraction();
+            }
+            else if (eject != null)
+            {
+                eject.OnHandlePull?.Invoke();
+            }
+            else if (door != null)
+            {
+                if (value != - 1)
+                    door.RemoteSetState(value);
+                else
+                    door.RemoteSetState(door.isLatched ? 1f : 0f); // 1f = to open, 0f = to close
+            }
+            else
+            {
+                try
+                {
+                    interactable.StartInteraction();
+                }
+                catch (NullReferenceException)
+                {
+                    interactable.OnInteract?.Invoke();
+                }
+            }
+        }
+
+        public static void AntiInteract(VRInteractable interactable)
+        {
+            VRButton button = interactable.GetComponent<VRButton>();
+            if (button != null)
+            {
+                interactable.StopInteraction();
+                button.Vrint_OnStopInteraction(null);
+            }
+            else
+            {
+                interactable.StopInteraction();
+            }
+        }
+    }
+}

--- a/TriquetraInput2/Interactions.cs
+++ b/TriquetraInput2/Interactions.cs
@@ -5,11 +5,15 @@ namespace Triquetra.Input
 {
     public static class Interactions
     {
-        const float knobTwistSpeed = 0.025f;
-        public static void TwistKnob(VRTwistKnob twistKnob, bool antiClockwise, float delta = knobTwistSpeed)
+        const float knobTwistSpeed = 0.1f;
+        public static void MoveTwistKnob(VRTwistKnob twistKnob, bool antiClockwise, float delta = knobTwistSpeed)
         {
-            //twistKnob.OnTwistDelta?.Invoke(antiClockwise ? -0.1f : 0.1f);
             twistKnob.SetKnobValue(twistKnob.currentValue + (antiClockwise ? -knobTwistSpeed : knobTwistSpeed));
+        }
+        
+        public static void SetTwistKnob(VRTwistKnob twistKnob, float value)
+        {
+            twistKnob.SetKnobValue(value);
         }
 
         public static void MoveLever(VRLever lever, int delta = 1, bool clamp = false)
@@ -53,9 +57,10 @@ namespace Triquetra.Input
             throttle.RemoteSetThrottleForceEvents(Math.Min(Math.Max(value, 0f), 1f));
         }
 
-        public static void Interact(VRInteractable interactable, int value = -1)
+        public static void Interact(VRInteractable interactable, float value = float.MinValue, bool antiClockwise = true)
         {
             VRLever lever = interactable.GetComponent<VRLever>();
+            VRTwistKnob twistKnob = interactable.GetComponent<VRTwistKnob>();
             VRTwistKnobInt twistKnobInt = interactable.GetComponent<VRTwistKnobInt>();
             VRButton button = interactable.GetComponent<VRButton>();
             EjectHandle eject = interactable.GetComponent<EjectHandle>();
@@ -64,15 +69,22 @@ namespace Triquetra.Input
 
             if (lever != null)
             {
-                if (value != -1)
-                    SetLever(lever, value);
+                if (value != float.MinValue)
+                    SetLever(lever, (int)value);
                 else
                     MoveLever(lever, 1);
             }
+            else if (twistKnob != null)
+            {
+                if (value != float.MinValue)
+                    SetTwistKnob(twistKnob, value);
+                else
+                    MoveTwistKnob(twistKnob, antiClockwise);
+            }
             else if (twistKnobInt != null)
             {
-                if (value != -1)
-                    SetTwistKnobInt(twistKnobInt, value);
+                if (value != float.MinValue)
+                    SetTwistKnobInt(twistKnobInt, (int)value);
                 else
                     MoveTwistKnobInt(twistKnobInt, 1);
             }
@@ -90,7 +102,7 @@ namespace Triquetra.Input
             }
             else if (door != null)
             {
-                if (value != - 1)
+                if (value != float.MinValue)
                     door.RemoteSetState(value);
                 else
                     door.RemoteSetState(door.isLatched ? 1f : 0f); // 1f = to open, 0f = to close

--- a/TriquetraInput2/Plugin.cs
+++ b/TriquetraInput2/Plugin.cs
@@ -38,8 +38,8 @@ namespace Triquetra.Input
             imguiObject.AddComponent<TriquetraInputBinders>();
             GameObject.DontDestroyOnLoad(imguiObject);
 
-            bindingsPath = PilotSaveManager.saveDataPath + "/triquetrainput.xml";
-            LoadBindings();
+            bindingsPath = PilotSaveManager.saveDataPath;
+            LoadBindings("triquetrainput.xml");
         }
 
         public void Disable()
@@ -54,7 +54,7 @@ namespace Triquetra.Input
             return buildIndex == 7 || buildIndex == 11;
         }
 
-        public static void SaveBindings()
+        public static void SaveBindings(string filename)
         {
             XmlSerializer serializer = new XmlSerializer(Binding.Bindings.GetType());
             using (StringWriter writer = new StringWriter())
@@ -62,18 +62,19 @@ namespace Triquetra.Input
                 serializer.Serialize(writer, Binding.Bindings);
                 Instance.Log(writer.ToString());
             }
-            using (TextWriter writer = new StreamWriter(bindingsPath))
+            using (TextWriter writer = new StreamWriter($"{bindingsPath}/{filename}"))
             {
                 serializer.Serialize(writer, Binding.Bindings);
             }
         }
 
-        public static void LoadBindings()
+        public static void LoadBindings(string filename)
         {
+            Binding.Bindings.Clear();
             XmlSerializer serializer = new XmlSerializer(Binding.Bindings.GetType());
-            if (File.Exists(bindingsPath))
+            if (File.Exists($"{bindingsPath}/{filename}"))
             {
-                using (Stream reader = new FileStream(bindingsPath, FileMode.Open))
+                using (Stream reader = new FileStream($"{bindingsPath}/{filename}", FileMode.Open))
                 {
                     lock (Binding.Bindings)
                     {

--- a/TriquetraInput2/Plugin.cs
+++ b/TriquetraInput2/Plugin.cs
@@ -80,6 +80,12 @@ namespace Triquetra.Input
                         Binding.Bindings = (List<Binding>)serializer.Deserialize(reader);
                     }
                 }
+
+                var devices = Binding.directInput.GetDevices().Where(Binding.IsJoystick).ToList();
+                foreach (var binding in Binding.Bindings)
+                {
+                    binding.CreateController(devices);
+                }
             }
         }
     }

--- a/TriquetraInput2/TriquetraInput2.csproj
+++ b/TriquetraInput2/TriquetraInput2.csproj
@@ -31,15 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\0Harmony.dll</HintPath>
-    </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\Dependencies\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ModLoader">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_ModLoader\ModLoader.dll</HintPath>
+      <HintPath>..\Dependencies\ModLoader.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
@@ -54,31 +52,23 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="TriquetraInteractions">
-      <HintPath>..\dependencies\TriquetraInteractions.dll</HintPath>
-    </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\Dependencies\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\Dependencies\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\Dependencies\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UIElementsModule">
-      <HintPath>P:\games\Steam\steamapps\common\VTOL VR\VTOLVR_Data\Managed\UnityEngine.UIElementsModule.dll</HintPath>
+      <HintPath>..\Dependencies\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Binding.cs" />
     <Compile Include="ControllerAction.cs" />
+    <Compile Include="Interactions.cs" />
     <Compile Include="KeyboardKey.cs" />
     <Compile Include="Plugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/TriquetraInput2/TriquetraInputBinders.cs
+++ b/TriquetraInput2/TriquetraInputBinders.cs
@@ -28,6 +28,7 @@ namespace Triquetra.Input
         public bool Enabled = true;
         private string textFilter = "";
         private Dictionary<Binding, bool> collapsedBindings = new Dictionary<Binding, bool>();
+        private string activeBindings = "Default";
 
         public void OnGUI()
         {
@@ -35,6 +36,8 @@ namespace Triquetra.Input
                 windowRect = GUI.Window(500, windowRect, DoWindow, "Binders Display");
         }
 
+        private const int loadSaveButtonWidth = 148;
+        
         void DoWindow(int windowID)
         {
             GUI.DragWindow(new Rect(0, 0, 10000, 20));
@@ -44,18 +47,189 @@ namespace Triquetra.Input
             Enabled = GUILayout.Toggle(Enabled, "Enabled");
 
             GUI.enabled = Enabled;
-
+            
+            GUILayout.BeginHorizontal();
+            {
+                GUILayout.Label("Active bindings");
+                GUILayout.Label(activeBindings);
+            }
+            GUILayout.EndHorizontal();
+            
             GUILayout.BeginHorizontal();
             {
                 try
                 {
-                    if (GUILayout.Button("Load"))
+                    GUILayout.Label("Default: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
                     {
-                        Plugin.LoadBindings();
+                        Plugin.LoadBindings("triquetrainput.xml");
+                        activeBindings = "Default";
                     }
-                    if (GUILayout.Button("Save"))
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
                     {
-                        Plugin.SaveBindings();
+                        Plugin.SaveBindings("triquetrainput.xml");
+                        activeBindings = "Default";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("AV-42C: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_av42c.xml");
+                        activeBindings = "AV-42C";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_av42c.xml");
+                        activeBindings = "AV-42C";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("F/A-26B: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_fa26b.xml");
+                        activeBindings = "F/A-26B";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_fa26b.xml");
+                        activeBindings = "F/A-26B";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("F-45A: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_f45a.xml");
+                        activeBindings = "F-45A";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_f45a.xml");
+                        activeBindings = "F-45A";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("AH-94 Front: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_ah94_front.xml");
+                        activeBindings = "AH-94 Front";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_ah94_front.xml");
+                        activeBindings = "AH-94 Front";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("AH-94 Rear: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_ah94_rear.xml");
+                        activeBindings = "AH-94 Rear";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_ah94_rear.xml");
+                        activeBindings = "AH-94 Rear";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("T-55 Front: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_t55_front.xml");
+                        activeBindings = "T-55 Front";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_t55_front.xml");
+                        activeBindings = "T-55 Front";
+                    }
+                }
+                catch (Exception e)
+                {
+                    Plugin.Instance.Log(e.Message);
+                }
+            }
+            GUILayout.EndHorizontal();
+            
+            GUILayout.BeginHorizontal();
+            {
+                try
+                {
+                    GUILayout.Label("T-55 Rear: ");
+                    if (GUILayout.Button("Load", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.LoadBindings("triquetrainput_t55_rear.xml");
+                        activeBindings = "T-55 Rear";
+                    }
+                    if (GUILayout.Button("Save", GUILayout.Width(loadSaveButtonWidth)))
+                    {
+                        Plugin.SaveBindings("triquetrainput_t55_rear.xml");
+                        activeBindings = "T-55 Rear";
                     }
                 }
                 catch (Exception e)
@@ -704,7 +878,7 @@ namespace Triquetra.Input
             {
                 if (GUILayout.Button("Create Joystick Binding"))
                 {
-                    Binding.Bindings.Add(new Binding());
+                    Binding.Bindings.Add(new Binding(false));
                 }
 
                 if (GUILayout.Button("Create Keyboard Binding"))

--- a/TriquetraInput2/TriquetraInputBinders.cs
+++ b/TriquetraInput2/TriquetraInputBinders.cs
@@ -286,6 +286,72 @@ namespace Triquetra.Input
                                 binding.VRInteractName = GUILayout.TextField(binding.VRInteractName);
                             }
                             GUILayout.EndHorizontal();
+                            
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("└ VRInteract Type: " + binding.VRInteractType);
+                                if (GUILayout.Button(binding.VRInteractTypeSelectOpen ? "Cancel" : "Select"))
+                                {
+                                    binding.VRInteractTypeSelectOpen = !binding.VRInteractTypeSelectOpen;
+                                }
+                            }
+                            GUILayout.EndHorizontal();
+
+                            if (binding.VRInteractTypeSelectOpen)
+                            {
+                                foreach (VRInteractType interactType in Enum.GetValues(typeof(VRInteractType)))
+                                {
+                                    if (GUILayout.Button(interactType.ToString()))
+                                    {
+                                        binding.VRInteractType = interactType;
+                                        binding.VRInteractTypeSelectOpen = false;
+                                    }
+                                }
+                            }
+                            
+                            if (binding.VRInteractType == VRInteractType.FixedValue)
+                            {
+                                GUILayout.BeginHorizontal();
+                                {
+                                    GUILayout.Label("Fixed Value: ");
+                                    GUILayout.Label(binding.Value.ToString());
+                                    binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 8);
+                                }
+                                GUILayout.EndHorizontal();
+                            }
+                        }
+                        else if (binding.OutputAction == ControllerAction.MFDInteract || binding.OutputAction == ControllerAction.MMFDInteract)
+                        {
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("MFD Index: ");
+                                GUILayout.Label(binding.Value.ToString());
+                                binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 3);
+                            }
+                            GUILayout.EndHorizontal();
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("└ MFD Action: " + binding.MFDAction);
+                                if (GUILayout.Button(binding.MFDActionSelectOpen ? "Cancel" : "Select"))
+                                {
+                                    binding.MFDActionSelectOpen = !binding.MFDActionSelectOpen;
+                                }
+                            }
+                            GUILayout.EndHorizontal();
+
+                            if (binding.MFDActionSelectOpen)
+                            {
+                                foreach (MFDAction mfdAction in Enum.GetValues(typeof(MFDAction)))
+                                {
+                                    if (binding.OutputAction == ControllerAction.MMFDInteract && mfdAction < MFDAction.TogglePower)
+                                        continue;
+                                    if (GUILayout.Button(mfdAction.ToString()))
+                                    {
+                                        binding.MFDAction           = mfdAction;
+                                        binding.MFDActionSelectOpen = false;
+                                    }
+                                }
+                            }
                         }
 
                         if (binding.OutputActionSelectOpen)
@@ -536,6 +602,72 @@ namespace Triquetra.Input
                                 binding.VRInteractName = GUILayout.TextField(binding.VRInteractName);
                             }
                             GUILayout.EndHorizontal();
+                            
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("└ VRInteract Type: " + binding.VRInteractType);
+                                if (GUILayout.Button(binding.VRInteractTypeSelectOpen ? "Cancel" : "Select"))
+                                {
+                                    binding.VRInteractTypeSelectOpen = !binding.VRInteractTypeSelectOpen;
+                                }
+                            }
+                            GUILayout.EndHorizontal();
+
+                            if (binding.VRInteractTypeSelectOpen)
+                            {
+                                foreach (VRInteractType interactType in Enum.GetValues(typeof(VRInteractType)))
+                                {
+                                    if (GUILayout.Button(interactType.ToString()))
+                                    {
+                                        binding.VRInteractType = interactType;
+                                        binding.VRInteractTypeSelectOpen = false;
+                                    }
+                                }
+                            }
+                            
+                            if (binding.VRInteractType == VRInteractType.FixedValue)
+                            {
+                                GUILayout.BeginHorizontal();
+                                {
+                                    GUILayout.Label("  └ Fixed Value: ");
+                                    GUILayout.Label(binding.Value.ToString());
+                                    binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 8);
+                                }
+                                GUILayout.EndHorizontal();
+                            }
+                        }
+                        else if (binding.OutputAction == ControllerAction.MFDInteract || binding.OutputAction == ControllerAction.MMFDInteract)
+                        {
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("MFD Index: ");
+                                GUILayout.Label(binding.Value.ToString());
+                                binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 3);
+                            }
+                            GUILayout.EndHorizontal();
+                            GUILayout.BeginHorizontal();
+                            {
+                                GUILayout.Label("└ MFD Action: " + binding.MFDAction);
+                                if (GUILayout.Button(binding.MFDActionSelectOpen ? "Cancel" : "Select"))
+                                {
+                                    binding.MFDActionSelectOpen = !binding.MFDActionSelectOpen;
+                                }
+                            }
+                            GUILayout.EndHorizontal();
+
+                            if (binding.MFDActionSelectOpen)
+                            {
+                                foreach (MFDAction mfdAction in Enum.GetValues(typeof(MFDAction)))
+                                {
+                                    if (binding.OutputAction == ControllerAction.MMFDInteract && mfdAction < MFDAction.TogglePower)
+                                        continue;
+                                    if (GUILayout.Button(mfdAction.ToString()))
+                                    {
+                                        binding.MFDAction           = mfdAction;
+                                        binding.MFDActionSelectOpen = false;
+                                    }
+                                }
+                            }
                         }
 
                         if (binding.Controller != null)
@@ -669,6 +801,7 @@ namespace Triquetra.Input
                 ControllerActions.Joystick.UpdateStick();
                 ControllerActions.Joystick.UpdateThumbstick();
                 ControllerActions.Throttle.UpdateThumbstick();
+                ControllerActions.Autopilot.UpdateAutopilot();
             }
         }
 

--- a/TriquetraInput2/TriquetraInputBinders.cs
+++ b/TriquetraInput2/TriquetraInputBinders.cs
@@ -776,38 +776,41 @@ namespace Triquetra.Input
                                 binding.VRInteractName = GUILayout.TextField(binding.VRInteractName);
                             }
                             GUILayout.EndHorizontal();
-                            
-                            GUILayout.BeginHorizontal();
-                            {
-                                GUILayout.Label("└ VRInteract Type: " + binding.VRInteractType);
-                                if (GUILayout.Button(binding.VRInteractTypeSelectOpen ? "Cancel" : "Select"))
-                                {
-                                    binding.VRInteractTypeSelectOpen = !binding.VRInteractTypeSelectOpen;
-                                }
-                            }
-                            GUILayout.EndHorizontal();
 
-                            if (binding.VRInteractTypeSelectOpen)
-                            {
-                                foreach (VRInteractType interactType in Enum.GetValues(typeof(VRInteractType)))
-                                {
-                                    if (GUILayout.Button(interactType.ToString()))
-                                    {
-                                        binding.VRInteractType = interactType;
-                                        binding.VRInteractTypeSelectOpen = false;
-                                    }
-                                }
-                            }
-                            
-                            if (binding.VRInteractType == VRInteractType.FixedValue)
+                            if (!binding.IsOffsetAxis)
                             {
                                 GUILayout.BeginHorizontal();
                                 {
-                                    GUILayout.Label("  └ Fixed Value: ");
-                                    GUILayout.Label(binding.Value.ToString());
-                                    binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 8);
+                                    GUILayout.Label("└ VRInteract Type: " + binding.VRInteractType);
+                                    if (GUILayout.Button(binding.VRInteractTypeSelectOpen ? "Cancel" : "Select"))
+                                    {
+                                        binding.VRInteractTypeSelectOpen = !binding.VRInteractTypeSelectOpen;
+                                    }
                                 }
                                 GUILayout.EndHorizontal();
+
+                                if (binding.VRInteractTypeSelectOpen)
+                                {
+                                    foreach (VRInteractType interactType in Enum.GetValues(typeof(VRInteractType)))
+                                    {
+                                        if (GUILayout.Button(interactType.ToString()))
+                                        {
+                                            binding.VRInteractType           = interactType;
+                                            binding.VRInteractTypeSelectOpen = false;
+                                        }
+                                    }
+                                }
+
+                                if (binding.VRInteractType == VRInteractType.FixedValue)
+                                {
+                                    GUILayout.BeginHorizontal();
+                                    {
+                                        GUILayout.Label("  └ Fixed Value: ");
+                                        GUILayout.Label(binding.Value.ToString());
+                                        binding.Value = (int)GUILayout.HorizontalSlider(binding.Value, 0, 8);
+                                    }
+                                    GUILayout.EndHorizontal();
+                                }
                             }
                         }
                         else if (binding.OutputAction == ControllerAction.MFDInteract || binding.OutputAction == ControllerAction.MMFDInteract)


### PR DESCRIPTION
The FindJoystick method was not able to handle the multiple joysticks the EF24 has. This fixes that for now. Currently only the frontseat of the jet is usable, since the backseat joysticks don't map to anything.
I'm also working on a way to sweep the wings, but that will be a different pull request