### PR TITLE
Fix joystick in EF24

### DIFF
--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -458,12 +458,9 @@ namespace Triquetra.Input
             {
                 var joysticks = GameObject.FindObjectsOfType<VRJoystick>(false);
 
-                var joystick = joysticks.FirstOrDefault();
-                if (joysticks.Length > 1)
-                {
-                    joystick = joysticks.FirstOrDefault(stick => stick.name == "joyInteractable_sideFront");
-                }
-
+                var joystick = joysticks.FirstOrDefault(stick => stick.name == "joyInteractable_sideFront") ??
+                        joysticks.FirstOrDefault();
+                    
                 return joystick;
             }
 

--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -456,7 +456,15 @@ namespace Triquetra.Input
 
             internal static VRJoystick FindJoystick()
             {
-                return GameObject.FindObjectOfType<VRJoystick>(false);
+                var joysticks = GameObject.FindObjectsOfType<VRJoystick>(false);
+
+                var joystick = joysticks.FirstOrDefault();
+                if (joysticks.Length > 1)
+                {
+                    joystick = joysticks.FirstOrDefault(stick => stick.name == "joyInteractable_sideFront");
+                }
+
+                return joystick;
             }
 
             private static bool menuButtonPressed = false;


### PR DESCRIPTION
The FindJoystick method was not able to handle the multiple joysticks the EF24 has. This fixes that for now. Currently only the frontseat of the jet is usable, since the backseat joysticks don't map to anything.
I'm also working on a way to sweep the wings, but that will be a different pull request