### PR TITLE
Add an action to dump VRInteractable names to the log file

### DIFF
--- a/TriquetraInput2/Binding.cs
+++ b/TriquetraInput2/Binding.cs
@@ -237,6 +237,10 @@ namespace Triquetra.Input
                             Interactions.AntiInteract(interactable);
                     }
                 }
+                else if (OutputAction == ControllerAction.DumpVRInteractables)
+                {
+                    ControllerActions.DumpVRInteractables(this, joystickValue);
+                }
             }
         }
 

--- a/TriquetraInput2/ControllerAction.cs
+++ b/TriquetraInput2/ControllerAction.cs
@@ -30,7 +30,8 @@ namespace Triquetra.Input
         NightVisionGoggles,
         PTT,
         VRInteract,
-        Print
+        Print,
+        DumpVRInteractables
     }
 
     public static class ControllerActions
@@ -481,6 +482,15 @@ namespace Triquetra.Input
         public static void Print(Binding binding, int joystickValue)
         {
             Plugin.Write($"Triquetra.Input: Axis is {binding.Offset}. Value is {joystickValue}");
+        }
+
+        public static void DumpVRInteractables(Binding binding, int joystickValue)
+        {
+            Plugin.Write("Triquetra.VRInteractables:");
+            foreach (VRInteractable x in GameObject.FindObjectsOfType<VRInteractable>(false))
+            {
+                Plugin.Write($"  - {x.interactableName}");
+            }
         }
 
         internal static void TryGetSticks()


### PR DESCRIPTION
Add an action that read and dump all VRInteractable variables to the player log file (for further configuration).